### PR TITLE
Remove unused player name retrieval in Gameworld1 constructor

### DIFF
--- a/core/src/main/java/com/dainsleif/hartebeest/world/Gameworld1.java
+++ b/core/src/main/java/com/dainsleif/hartebeest/world/Gameworld1.java
@@ -28,7 +28,6 @@ public class Gameworld1 implements Screen {
     KeyHandler keyHandler;
 
     public Gameworld1() {
-        GameInfo.getPlayerName();
         System.out.println("Width: " + GameInfo.WIDTH + " Height: " + GameInfo.HEIGHT);
 
         // Load map


### PR DESCRIPTION
This pull request includes a small change to the `Gameworld1` class in the `core/src/main/java/com/dainsleif/hartebeest/world/Gameworld1.java` file. The change removes an unnecessary call to `GameInfo.getPlayerName()` in the constructor.

* [`core/src/main/java/com/dainsleif/hartebeest/world/Gameworld1.java`](diffhunk://#diff-d3eedd05c869fb47fff54c36d2a7284f7a91f87caa351a3e3f403f7be8a61260L31): Removed the call to `GameInfo.getPlayerName()` in the constructor.